### PR TITLE
Improve filter UX

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,6 +84,21 @@ document.querySelector('#clearFilters').addEventListener('click', () => {
   switches.forEach((checkbox) => {
     checkbox.checked = false;
   });
+  const name = document.querySelector('#name').value;
+  if (name) {
+    offset = 0;
+    fetchResults(name, offset);
+  }
+});
+
+document.querySelectorAll('input[name="list"]').forEach((checkbox) => {
+  checkbox.addEventListener('change', () => {
+    const name = document.querySelector('#name').value;
+    if (name) {
+      offset = 0;
+      fetchResults(name, offset);
+    }
+  });
 });
 
 function sortResults(results) {


### PR DESCRIPTION
## Summary
- update filter reset handler to immediately re-query if a search term is present
- trigger search whenever an individual filter switch changes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687792310cd0832dbf9e1a5ba16be440