### PR TITLE
Fix live results updating when filters change

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,27 +77,30 @@ function renderHistory() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', renderHistory);
+document.addEventListener('DOMContentLoaded', () => {
+  renderHistory();
 
-document.querySelector('#clearFilters').addEventListener('click', () => {
-  const switches = document.querySelectorAll('input[name="list"]');
-  switches.forEach((checkbox) => {
-    checkbox.checked = false;
-  });
-  const name = document.querySelector('#name').value;
-  if (name) {
-    offset = 0;
-    fetchResults(name, offset);
-  }
-});
-
-document.querySelectorAll('input[name="list"]').forEach((checkbox) => {
-  checkbox.addEventListener('change', () => {
+  const clearBtn = document.querySelector('#clearFilters');
+  clearBtn.addEventListener('click', () => {
+    const switches = document.querySelectorAll('input[name="list"]');
+    switches.forEach((checkbox) => {
+      checkbox.checked = false;
+    });
     const name = document.querySelector('#name').value;
     if (name) {
       offset = 0;
       fetchResults(name, offset);
     }
+  });
+
+  document.querySelectorAll('input[name="list"]').forEach((checkbox) => {
+    checkbox.addEventListener('change', () => {
+      const name = document.querySelector('#name').value;
+      if (name) {
+        offset = 0;
+        fetchResults(name, offset);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure filter event handlers register after DOM is ready
- update clear filters logic and filter change listener inside DOMContentLoaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877946094fc832d88d63b143aef69c7