### PR TITLE
Add filter toggling and 'only' options

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,90 +88,103 @@
           <!-- Row for responsive columns -->
           <div class="row">
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="dpl" name="list" value="DPL" checked>
-                <label class="form-check-label" for="dpl">Denied Persons List (DPL)</label>
+                <label class="form-check-label ms-1" for="dpl">Denied Persons List (DPL)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="DPL">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="el" name="list" value="EL" checked>
-                <label class="form-check-label" for="el">Entity List (EL)</label>
+                <label class="form-check-label ms-1" for="el">Entity List (EL)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="EL">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="meu" name="list" value="MEU" checked>
-                <label class="form-check-label" for="meu">Military End User (MEU)</label>
+                <label class="form-check-label ms-1" for="meu">Military End User (MEU)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="MEU">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="uvl" name="list" value="UVL" checked>
-                <label class="form-check-label" for="uvl">Unverified List (UVL)</label>
+                <label class="form-check-label ms-1" for="uvl">Unverified List (UVL)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="UVL">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="isn" name="list" value="ISN" checked>
-                <label class="form-check-label" for="isn">Nonproliferation Sanctions (ISN)</label>
+                <label class="form-check-label ms-1" for="isn">Nonproliferation Sanctions (ISN)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="ISN">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="dtc" name="list" value="DTC" checked>
-                <label class="form-check-label" for="dtc">ITAR Debarred (DTC)</label>
+                <label class="form-check-label ms-1" for="dtc">ITAR Debarred (DTC)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="DTC">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="cap" name="list" value="CAP" checked>
-                <label class="form-check-label" for="cap">CAPTA List (CAP)</label>
+                <label class="form-check-label ms-1" for="cap">CAPTA List (CAP)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="CAP">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="cmic" name="list" value="CMIC" checked>
-                <label class="form-check-label" for="cmic">Chinese Military-Industrial (CMIC)</label>
+                <label class="form-check-label ms-1" for="cmic">Chinese Military-Industrial (CMIC)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="CMIC">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="fse" name="list" value="FSE" checked>
-                <label class="form-check-label" for="fse">Foreign Sanctions Evaders (FSE)</label>
+                <label class="form-check-label ms-1" for="fse">Foreign Sanctions Evaders (FSE)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="FSE">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="mbs" name="list" value="MBS" checked>
-                <label class="form-check-label" for="mbs">Non-SDN Menu-Based (MBS)</label>
+                <label class="form-check-label ms-1" for="mbs">Non-SDN Menu-Based (MBS)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="MBS">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="plc" name="list" value="PLC" checked>
-                <label class="form-check-label" for="plc">Palestinian Legislative Council (PLC)</label>
+                <label class="form-check-label ms-1" for="plc">Palestinian Legislative Council (PLC)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="PLC">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="ssi" name="list" value="SSI" checked>
-                <label class="form-check-label" for="ssi">Sectoral Sanctions (SSI)</label>
+                <label class="form-check-label ms-1" for="ssi">Sectoral Sanctions (SSI)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SSI">Only</button>
               </div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check">
+              <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="sdn" name="list" value="SDN" checked>
-                <label class="form-check-label" for="sdn">Specially Designated Nationals (SDN)</label>
+                <label class="form-check-label ms-1" for="sdn">Specially Designated Nationals (SDN)</label>
+                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SDN">Only</button>
               </div>
             </div>
             <!-- Small Toggle Filters Button -->
             <hr class="mt-3 mb-3"/>
             <div class="col-12 col-md-6 col-lg-4">
               <button class="btn-close" aria-label="Close" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-expanded="false" aria-controls="filterOptions"></button>
-              <!-- Clear Filters Button -->
+              <!-- Toggle Filters Button -->
               <button class="btn btn-light btn-sm" type="button" id="clearFilters">
-                Clear Filters
+                Toggle Filters
               </button>
           </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -83,14 +83,29 @@ document.addEventListener('DOMContentLoaded', () => {
   const clearBtn = document.querySelector('#clearFilters');
   clearBtn.addEventListener('click', () => {
     const switches = document.querySelectorAll('input[name="list"]');
+    const anyUnchecked = Array.from(switches).some((cb) => !cb.checked);
     switches.forEach((checkbox) => {
-      checkbox.checked = false;
+      checkbox.checked = anyUnchecked;
     });
     const name = document.querySelector('#name').value;
     if (name) {
       offset = 0;
       fetchResults(name, offset);
     }
+  });
+
+  document.querySelectorAll('.only-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const filter = btn.dataset.filter;
+      document.querySelectorAll('input[name="list"]').forEach((cb) => {
+        cb.checked = cb.value === filter;
+      });
+      const name = document.querySelector('#name').value;
+      if (name) {
+        offset = 0;
+        fetchResults(name, offset);
+      }
+    });
   });
 
   document.querySelectorAll('input[name="list"]').forEach((checkbox) => {


### PR DESCRIPTION
## Summary
- add new 'Only' buttons for each filter
- change clear filters button to toggle all filters
- update script to support toggling and 'only' buttons

## Testing
- `tidy -errors index.html`


------
https://chatgpt.com/codex/tasks/task_e_6877b7894c70832db2a33910ac82203d