### PR TITLE
Improve search history and filter controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
       <div class="mb-2" id="history-container">
         <label class="form-label">Recent Searches</label>
         <div id="search-history" class="d-flex flex-wrap gap-2"></div>
+        <button type="button" id="clear-history" class="btn btn-link btn-sm p-0 ms-2">Clear All</button>
       </div>
   
       <!-- Button to toggle filters -->
@@ -85,8 +86,13 @@
       <!-- Collapsible section for switches -->
       <div class="collapse mt-3" id="filterOptions">
         <div class="card card-body">
+          <div class="d-flex justify-content-between mb-3">
+            <button class="btn-close" aria-label="Close" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-expanded="false" aria-controls="filterOptions"></button>
+            <button class="btn btn-light btn-sm" type="button" id="clearFilters">Toggle Filters</button>
+          </div>
+          <h5>List Filters</h5>
           <!-- Row for responsive columns -->
-            <div class="row">
+          <div class="row">
               <div class="col-12 col-md-6 col-lg-4">
               <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="dpl" name="list" value="DPL" checked>
@@ -177,21 +183,11 @@
                 <label class="form-check-label ms-1" for="sdn">Specially Designated Nationals (SDN)</label>
                 <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SDN">Only</button>
               </div>
-              </div>
-
-              <!-- Small Toggle Filters Button -->
-              <hr class="mt-3 mb-3"/>
-              <div class="col-12 col-md-6 col-lg-4">
-                <button class="btn-close" aria-label="Close" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-expanded="false" aria-controls="filterOptions"></button>
-                <!-- Toggle Filters Button -->
-                <button class="btn btn-light btn-sm" type="button" id="clearFilters">
-                  Toggle Filters
-                </button>
-              </div>
             </div>
 
-            <hr class="mt-3 mb-3"/>
-            <div class="row">
+          <hr class="mt-3 mb-3"/>
+          <h5>Type Filters</h5>
+          <div class="row">
               <div class="col-12 col-md-6 col-lg-3">
                 <div class="form-check d-flex align-items-center">
                   <input class="form-check-input" type="checkbox" id="type-entity" name="type" value="Entity" checked>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ const errorDiv = document.querySelector('#error-message');
 const prevBtn = document.querySelector('#prev-btn');
 const nextBtn = document.querySelector('#next-btn');
 const historyList = document.querySelector('#search-history');
+const clearHistoryBtn = document.querySelector('#clear-history');
 
 document.querySelector('#page-size').addEventListener('change', (e) => {
   pageSize = parseInt(e.target.value, 10);
@@ -60,10 +61,25 @@ function updateHistory(term) {
   renderHistory();
 }
 
+function removeFromHistory(term) {
+  let history = JSON.parse(localStorage.getItem('searchHistory') || '[]');
+  history = history.filter((t) => t !== term);
+  localStorage.setItem('searchHistory', JSON.stringify(history));
+  renderHistory();
+}
+
+function clearHistory() {
+  localStorage.removeItem('searchHistory');
+  renderHistory();
+}
+
 function renderHistory() {
   const history = JSON.parse(localStorage.getItem('searchHistory') || '[]');
   historyList.innerHTML = '';
   history.forEach((term) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'history-entry';
+
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'btn btn-link p-0 history-item';
@@ -73,12 +89,31 @@ function renderHistory() {
       offset = 0;
       fetchResults(term, offset);
     });
-    historyList.appendChild(btn);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'btn-close btn-sm ms-1';
+    removeBtn.setAttribute('aria-label', 'Remove');
+    removeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      removeFromHistory(term);
+    });
+
+    wrapper.appendChild(btn);
+    wrapper.appendChild(removeBtn);
+    historyList.appendChild(wrapper);
   });
+  if (clearHistoryBtn) {
+    clearHistoryBtn.style.display = history.length ? 'inline-block' : 'none';
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   renderHistory();
+
+  if (clearHistoryBtn) {
+    clearHistoryBtn.addEventListener('click', clearHistory);
+  }
 
   const clearBtn = document.querySelector('#clearFilters');
   clearBtn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -13,3 +13,14 @@ body {
 .history-item {
   text-decoration: none;
 }
+
+.history-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.history-entry .btn-close {
+  width: 0.5rem;
+  height: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- allow removing individual search history items and clearing all
- move filter close/toggle controls to the top of the card
- add headings for list and type filters
- style history item removal buttons

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68781ba76630832da837c7a10d31b60f