### PR TITLE
Show API errors in results area

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Use the "Prev" and "Next" buttons to navigate through the results. The page size
 
 The app uses the Fetch API to send a GET request to the Consolidated Screening List API with the specified search query and offset. The API returns a JSON object containing the search results, which are then displayed in a table using JavaScript.
 
+If a request fails, an error banner is shown and the full API error message is also displayed in the results area to help with debugging.
+
 The "Prev" and "Next" buttons are implemented using event listeners that update the offset and resubmit the search query when clicked.
 
 ## Future improvements

--- a/script.js
+++ b/script.js
@@ -208,6 +208,9 @@ function updateFilterCounts(sources) {
   spinner.style.display = 'block';
   errorDiv.textContent = '';
 
+  const resultsDiv = document.querySelector('#results');
+  resultsDiv.innerHTML = '';
+
   fetch(url, {
     method: 'GET',
     headers: {
@@ -215,17 +218,17 @@ function updateFilterCounts(sources) {
       'subscription-key': 'b9730532d6ba42fabc7e93f2b1c1df60',
     },
   })
-    .then((response) => {
+    .then(async (response) => {
       if (!response.ok) {
-        throw new Error(response.statusText);
+        const text = await response.text();
+        throw new Error(`HTTP ${response.status} ${response.statusText}: ${text}`);
       }
       return response.json();
-  })
+    })
     .then((data) => {
       total = data.total;
       document.querySelector('#total-results').textContent = `${total} Results`;
       updateFilterCounts(data.sources);
-      const resultsDiv = document.querySelector('#results');
       resultsDiv.innerHTML = '';
       if (data.total === 0) {
         resultsDiv.innerHTML = '<p>No results found</p>';
@@ -320,10 +323,15 @@ function updateFilterCounts(sources) {
       spinner.style.display = 'none';
       updateHistory(name);
     })
-    .catch(() => {
+    .catch((error) => {
       spinner.style.display = 'none';
       errorDiv.textContent = 'Failed to load results.';
-      document.querySelector('#results').innerHTML = '';
+      const alert = document.createElement('div');
+      alert.className = 'alert alert-danger';
+      alert.setAttribute('role', 'alert');
+      alert.textContent = error.message;
+      resultsDiv.innerHTML = '';
+      resultsDiv.appendChild(alert);
       prevBtn.style.display = 'none';
       nextBtn.style.display = 'none';
       updateFilterCounts([]);


### PR DESCRIPTION
## Summary
- surface API failure details by displaying them in the results area
- note error banner behaviour in README

## Testing
- `npx html-validate index.html` *(fails: Need to install the following packages: html-validate@9.7.1)*

------
https://chatgpt.com/codex/tasks/task_e_68781ee7d5b8832db71fe108dc3428ae