### PR TITLE
Refine filter panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,13 +81,18 @@
       <button class="btn btn-light btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-expanded="false" aria-controls="filterOptions">
         Filters
       </button>
-      
+
       <!-- Collapsible section for switches -->
       <div class="collapse mt-3" id="filterOptions">
         <div class="card card-body">
-          <!-- Row for responsive columns -->
-            <div class="row">
-              <div class="col-12 col-md-6 col-lg-4">
+          <div class="d-flex justify-content-between mb-2">
+            <h5 class="mb-0">Filters</h5>
+            <button class="btn-close" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-label="Close"></button>
+          </div>
+          <button class="btn btn-outline-secondary btn-sm mb-3" type="button" id="toggleFilters">Toggle All</button>
+          <h6>Lists</h6>
+          <div class="row mb-3">
+            <div class="col-12 col-md-6 col-lg-4">
               <div class="form-check d-flex align-items-center">
                 <input class="form-check-input" type="checkbox" id="dpl" name="list" value="DPL" checked>
                 <label class="form-check-label ms-1" for="dpl">Denied Persons List (DPL)</label>
@@ -177,49 +182,37 @@
                 <label class="form-check-label ms-1" for="sdn">Specially Designated Nationals (SDN)</label>
                 <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SDN">Only</button>
               </div>
-              </div>
-
-              <!-- Small Toggle Filters Button -->
-              <hr class="mt-3 mb-3"/>
-              <div class="col-12 col-md-6 col-lg-4">
-                <button class="btn-close" aria-label="Close" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-expanded="false" aria-controls="filterOptions"></button>
-                <!-- Toggle Filters Button -->
-                <button class="btn btn-light btn-sm" type="button" id="clearFilters">
-                  Toggle Filters
-                </button>
+            </div>
+          </div>
+          <h6>Types</h6>
+          <div class="row">
+            <div class="col-12 col-md-6 col-lg-3">
+              <div class="form-check d-flex align-items-center">
+                <input class="form-check-input" type="checkbox" id="type-entity" name="type" value="Entity" checked>
+                <label class="form-check-label ms-1" for="type-entity">Entity</label>
               </div>
             </div>
-
-            <hr class="mt-3 mb-3"/>
-            <div class="row">
-              <div class="col-12 col-md-6 col-lg-3">
-                <div class="form-check d-flex align-items-center">
-                  <input class="form-check-input" type="checkbox" id="type-entity" name="type" value="Entity" checked>
-                  <label class="form-check-label ms-1" for="type-entity">Entity</label>
-                </div>
-              </div>
-              <div class="col-12 col-md-6 col-lg-3">
-                <div class="form-check d-flex align-items-center">
-                  <input class="form-check-input" type="checkbox" id="type-vessel" name="type" value="Vessel" checked>
-                  <label class="form-check-label ms-1" for="type-vessel">Vessel</label>
-                </div>
-              </div>
-              <div class="col-12 col-md-6 col-lg-3">
-                <div class="form-check d-flex align-items-center">
-                  <input class="form-check-input" type="checkbox" id="type-individual" name="type" value="Individual" checked>
-                  <label class="form-check-label ms-1" for="type-individual">Individual</label>
-                </div>
-              </div>
-              <div class="col-12 col-md-6 col-lg-3">
-                <div class="form-check d-flex align-items-center">
-                  <input class="form-check-input" type="checkbox" id="type-unknown" name="type" value="Unknown" checked>
-                  <label class="form-check-label ms-1" for="type-unknown">Unknown</label>
-                </div>
+            <div class="col-12 col-md-6 col-lg-3">
+              <div class="form-check d-flex align-items-center">
+                <input class="form-check-input" type="checkbox" id="type-vessel" name="type" value="Vessel" checked>
+                <label class="form-check-label ms-1" for="type-vessel">Vessel</label>
               </div>
             </div>
-
+            <div class="col-12 col-md-6 col-lg-3">
+              <div class="form-check d-flex align-items-center">
+                <input class="form-check-input" type="checkbox" id="type-individual" name="type" value="Individual" checked>
+                <label class="form-check-label ms-1" for="type-individual">Individual</label>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-3">
+              <div class="form-check d-flex align-items-center">
+                <input class="form-check-input" type="checkbox" id="type-unknown" name="type" value="Unknown" checked>
+                <label class="form-check-label ms-1" for="type-unknown">Unknown</label>
+              </div>
+            </div>
           </div>
         </div>
+      </div>
       </form>
     
     

--- a/script.js
+++ b/script.js
@@ -80,8 +80,8 @@ function renderHistory() {
 document.addEventListener('DOMContentLoaded', () => {
   renderHistory();
 
-  const clearBtn = document.querySelector('#clearFilters');
-  clearBtn.addEventListener('click', () => {
+  const toggleBtn = document.querySelector('#toggleFilters');
+  toggleBtn.addEventListener('click', () => {
     const listSwitches = document.querySelectorAll('input[name="list"]');
     const typeSwitches = document.querySelectorAll('input[name="type"]');
     const allSwitches = [...listSwitches, ...typeSwitches];


### PR DESCRIPTION
## Summary
- reorganize filter pane with clearer headings and a toggle-all button
- update script to use `#toggleFilters`

## Testing
- `npx --yes html-validate index.html` *(fails: many existing HTML errors)*

------
https://chatgpt.com/codex/tasks/task_e_687825c7cfe0832d9d9d6b7e841cd5bc