### PR TITLE
Improve filter UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,125 +89,135 @@
             <h5 class="mb-0">Filters</h5>
             <button class="btn-close" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-label="Close"></button>
           </div>
-          <button class="btn btn-outline-secondary btn-sm mb-3" type="button" id="toggleFilters">Toggle All</button>
-          <h6>Lists</h6>
-          <div class="row mb-3">
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="dpl" name="list" value="DPL" checked>
-                <label class="form-check-label ms-1" for="dpl">Denied Persons List (DPL)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="DPL">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="el" name="list" value="EL" checked>
-                <label class="form-check-label ms-1" for="el">Entity List (EL)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="EL">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="meu" name="list" value="MEU" checked>
-                <label class="form-check-label ms-1" for="meu">Military End User (MEU)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="MEU">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="uvl" name="list" value="UVL" checked>
-                <label class="form-check-label ms-1" for="uvl">Unverified List (UVL)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="UVL">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="isn" name="list" value="ISN" checked>
-                <label class="form-check-label ms-1" for="isn">Nonproliferation Sanctions (ISN)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="ISN">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="dtc" name="list" value="DTC" checked>
-                <label class="form-check-label ms-1" for="dtc">ITAR Debarred (DTC)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="DTC">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="cap" name="list" value="CAP" checked>
-                <label class="form-check-label ms-1" for="cap">CAPTA List (CAP)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="CAP">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="cmic" name="list" value="CMIC" checked>
-                <label class="form-check-label ms-1" for="cmic">Chinese Military-Industrial (CMIC)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="CMIC">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="fse" name="list" value="FSE" checked>
-                <label class="form-check-label ms-1" for="fse">Foreign Sanctions Evaders (FSE)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="FSE">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="mbs" name="list" value="MBS" checked>
-                <label class="form-check-label ms-1" for="mbs">Non-SDN Menu-Based (MBS)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="MBS">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="plc" name="list" value="PLC" checked>
-                <label class="form-check-label ms-1" for="plc">Palestinian Legislative Council (PLC)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="PLC">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="ssi" name="list" value="SSI" checked>
-                <label class="form-check-label ms-1" for="ssi">Sectoral Sanctions (SSI)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SSI">Only</button>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-4">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="sdn" name="list" value="SDN" checked>
-                <label class="form-check-label ms-1" for="sdn">Specially Designated Nationals (SDN)</label>
-                <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SDN">Only</button>
-              </div>
-            </div>
-          </div>
-          <h6>Types</h6>
+          <button class="btn btn-outline-secondary btn-sm mb-3 w-auto" type="button" id="toggleFilters">Toggle All</button>
           <div class="row">
-            <div class="col-12 col-md-6 col-lg-3">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="type-entity" name="type" value="Entity" checked>
-                <label class="form-check-label ms-1" for="type-entity">Entity</label>
+            <div class="col-lg-8">
+              <h6>Lists</h6>
+              <div class="row mb-3">
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="dpl" name="list" value="DPL" checked>
+                    <label class="form-check-label ms-1" for="dpl">Denied Persons List (DPL)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="DPL">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="el" name="list" value="EL" checked>
+                    <label class="form-check-label ms-1" for="el">Entity List (EL)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="EL">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="meu" name="list" value="MEU" checked>
+                    <label class="form-check-label ms-1" for="meu">Military End User (MEU)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="MEU">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="uvl" name="list" value="UVL" checked>
+                    <label class="form-check-label ms-1" for="uvl">Unverified List (UVL)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="UVL">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="isn" name="list" value="ISN" checked>
+                    <label class="form-check-label ms-1" for="isn">Nonproliferation Sanctions (ISN)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="ISN">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="dtc" name="list" value="DTC" checked>
+                    <label class="form-check-label ms-1" for="dtc">ITAR Debarred (DTC)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="DTC">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="cap" name="list" value="CAP" checked>
+                    <label class="form-check-label ms-1" for="cap">CAPTA List (CAP)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="CAP">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="cmic" name="list" value="CMIC" checked>
+                    <label class="form-check-label ms-1" for="cmic">Chinese Military-Industrial (CMIC)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="CMIC">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="fse" name="list" value="FSE" checked>
+                    <label class="form-check-label ms-1" for="fse">Foreign Sanctions Evaders (FSE)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="FSE">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="mbs" name="list" value="MBS" checked>
+                    <label class="form-check-label ms-1" for="mbs">Non-SDN Menu-Based (MBS)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="MBS">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="plc" name="list" value="PLC" checked>
+                    <label class="form-check-label ms-1" for="plc">Palestinian Legislative Council (PLC)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="PLC">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="ssi" name="list" value="SSI" checked>
+                    <label class="form-check-label ms-1" for="ssi">Sectoral Sanctions (SSI)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SSI">Only</button>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="sdn" name="list" value="SDN" checked>
+                    <label class="form-check-label ms-1" for="sdn">Specially Designated Nationals (SDN)</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn" data-filter="SDN">Only</button>
+                  </div>
+                </div>
               </div>
             </div>
-            <div class="col-12 col-md-6 col-lg-3">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="type-vessel" name="type" value="Vessel" checked>
-                <label class="form-check-label ms-1" for="type-vessel">Vessel</label>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-3">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="type-individual" name="type" value="Individual" checked>
-                <label class="form-check-label ms-1" for="type-individual">Individual</label>
-              </div>
-            </div>
-            <div class="col-12 col-md-6 col-lg-3">
-              <div class="form-check d-flex align-items-center">
-                <input class="form-check-input" type="checkbox" id="type-unknown" name="type" value="Unknown" checked>
-                <label class="form-check-label ms-1" for="type-unknown">Unknown</label>
+            <div class="col-lg-4">
+              <h6>Types</h6>
+              <div class="row">
+                <div class="col-12">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="type-entity" name="type" value="Entity" checked>
+                    <label class="form-check-label ms-1" for="type-entity">Entity</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn-type" data-type="Entity">Only</button>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="type-vessel" name="type" value="Vessel" checked>
+                    <label class="form-check-label ms-1" for="type-vessel">Vessel</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn-type" data-type="Vessel">Only</button>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="type-individual" name="type" value="Individual" checked>
+                    <label class="form-check-label ms-1" for="type-individual">Individual</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn-type" data-type="Individual">Only</button>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="form-check d-flex align-items-center">
+                    <input class="form-check-input" type="checkbox" id="type-unknown" name="type" value="Unknown" checked>
+                    <label class="form-check-label ms-1" for="type-unknown">Unknown</label>
+                    <button type="button" class="btn btn-link p-0 ms-1 only-btn-type" data-type="Unknown">Only</button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -140,6 +140,20 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  document.querySelectorAll('.only-btn-type').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const type = btn.dataset.type;
+      document.querySelectorAll('input[name="type"]').forEach((cb) => {
+        cb.checked = cb.value === type;
+      });
+      const name = document.querySelector('#name').value;
+      if (name) {
+        offset = 0;
+        fetchResults(name, offset);
+      }
+    });
+  });
+
   document.querySelectorAll('input[name="list"]').forEach((checkbox) => {
     checkbox.addEventListener('change', () => {
       const name = document.querySelector('#name').value;


### PR DESCRIPTION
## Summary
- let lists take up two columns and stack types in the third column
- add "only" buttons for types
- shrink toggle-all button width

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878308812b4832dad4d198ab442f1db