### PR TITLE
Add numbered pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This app allows you to search the Consolidated Screening List, which is a databa
 
 To use the app, simply type a name in the search box and click the "Search" button. The app will retrieve a list of matching results from the Consolidated Screening List and display them in a table.
 
-Use the "Prev" and "Next" buttons to navigate through the results. The page size selector lets you choose how many results appear on each page. Results can also be sorted by name using the "Sort" dropdown and your last few searches are saved for quick access.
+Use the "Prev" and "Next" buttons or the numbered page buttons to navigate through the results. The page size selector lets you choose how many results appear on each page. Results can also be sorted by name using the "Sort" dropdown and your last few searches are saved for quick access.
 
 ## Technologies used
 
@@ -18,7 +18,7 @@ Use the "Prev" and "Next" buttons to navigate through the results. The page size
 
 The app uses the Fetch API to send a GET request to the Consolidated Screening List API with the specified search query and offset. The API returns a JSON object containing the search results, which are then displayed in a table using JavaScript.
 
-The "Prev" and "Next" buttons are implemented using event listeners that update the offset and resubmit the search query when clicked.
+The navigation buttons and page numbers update the offset and resubmit the search query when clicked.
 
 ## Future improvements
 

--- a/index.html
+++ b/index.html
@@ -212,7 +212,6 @@
     
     
     <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-      <p id="total-results" class="mb-0" aria-live="polite"></p>
       <label for="page-size" class="form-label mb-0">Results per page</label>
       <select id="page-size" class="form-select form-select-sm w-auto" aria-label="Results per page">
         <option value="10">10</option>
@@ -233,8 +232,14 @@
       </div>
     </div>
     <p id="error-message" class="text-danger" role="alert"></p>
-    <button id="prev-btn" class="btn btn-secondary" style="display: none;" aria-label="Previous page">Prev</button>
-    <button id="next-btn" class="btn btn-secondary" style="display: none;" aria-label="Next page">Next</button>
+      <div id="pagination-container" class="d-flex flex-column flex-sm-row align-items-center gap-2 my-3">
+        <div id="pagination-buttons" class="btn-group" role="group">
+          <button id="prev-btn" class="btn btn-secondary" style="display: none;" aria-label="Previous page">Prev</button>
+          <div id="page-numbers" class="btn-group"></div>
+          <button id="next-btn" class="btn btn-secondary" style="display: none;" aria-label="Next page">Next</button>
+        </div>
+        <p id="total-results" class="mb-0" aria-live="polite"></p>
+      </div>
   </div>
   
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,8 @@ let sortOrder = 'relevance';
 
 const spinner = document.querySelector('#loading-spinner');
 const errorDiv = document.querySelector('#error-message');
+const pageNumbers = document.querySelector("#page-numbers");
+const totalResultsEl = document.querySelector("#total-results");
 const prevBtn = document.querySelector('#prev-btn');
 const nextBtn = document.querySelector('#next-btn');
 const historyList = document.querySelector('#search-history');
@@ -229,8 +231,33 @@ function updateTypeCounts(results) {
     } else {
       label.classList.remove('fw-bold');
     }
+
   });
 }
+function renderPagination() {
+  pageNumbers.innerHTML = "";
+  const totalPages = Math.ceil(total / pageSize);
+  const currentPage = Math.floor(offset / pageSize) + 1;
+  let start = Math.max(1, currentPage - 2);
+  let end = Math.min(totalPages, start + 4);
+  if (end - start < 4) {
+    start = Math.max(1, end - 4);
+  }
+  for (let i = start; i <= end; i++) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-secondary";
+    if (i === currentPage) btn.classList.add("active");
+    btn.textContent = i;
+    btn.addEventListener("click", () => {
+      offset = (i - 1) * pageSize;
+      const name = document.querySelector("#name").value;
+      fetchResults(name, offset);
+    });
+    pageNumbers.appendChild(btn);
+  }
+}
+
 
   function fetchResults(name, offset) {
     const selectedLists = Array.from(document.querySelectorAll('input[name="list"]:checked'))
@@ -265,7 +292,7 @@ function updateTypeCounts(results) {
       updateFilterCounts(countData.sources);
       updateTypeCounts(data.results);
       total = data.total;
-      document.querySelector('#total-results').textContent = `${total} Results`;
+      totalResultsEl.textContent = `${total} Results`;
       const resultsDiv = document.querySelector('#results');
       resultsDiv.innerHTML = '';
       if (data.total === 0) {
@@ -274,12 +301,14 @@ function updateTypeCounts(results) {
         nextBtn.style.display = 'none';
         spinner.style.display = 'none';
         updateHistory(name);
+        pageNumbers.innerHTML = "";
         return;
       }
 
       prevBtn.style.display = offset > 0 ? 'inline-block' : 'none';
       nextBtn.style.display = offset + pageSize < total ? 'inline-block' : 'none';
 
+      renderPagination();
         const accordion = document.createElement('div');
         accordion.classList.add('accordion');
         accordion.setAttribute('id', 'accordionExample');
@@ -368,6 +397,8 @@ function updateTypeCounts(results) {
       errorDiv.textContent = 'Failed to load results.';
       document.querySelector('#results').innerHTML = '';
       prevBtn.style.display = 'none';
+      totalResultsEl.textContent = "";
+      pageNumbers.innerHTML = "";
       nextBtn.style.display = 'none';
       updateFilterCounts([]);
     });


### PR DESCRIPTION
## Summary
- add page numbers to paginate results
- show total results beside pagination controls
- update readme instructions for new page navigation

## Testing
- `node -e "new Function(require('fs').readFileSync('script.js'))"`

------
https://chatgpt.com/codex/tasks/task_e_687901f1b4b0832daa5ab52adcc26758