### PR TITLE
Align filters with sort controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,10 +62,25 @@
         <div id="search-history" class="d-flex flex-wrap gap-2"></div>
       </div>
   
-      <!-- Button to toggle filters -->
-      <button class="btn btn-light btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-expanded="false" aria-controls="filterOptions">
-        Filters
-      </button>
+      <div class="d-flex flex-column flex-sm-row justify-content-between align-items-center gap-2 mb-2">
+        <button class="btn btn-light btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#filterOptions" aria-expanded="false" aria-controls="filterOptions">
+          Filters
+        </button>
+        <div class="d-flex align-items-center gap-2">
+          <label for="page-size" class="form-label mb-0">Results per page</label>
+          <select id="page-size" class="form-select form-select-sm w-auto" aria-label="Results per page">
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+          </select>
+          <label for="sort" class="form-label mb-0">Sort</label>
+          <select id="sort" class="form-select form-select-sm w-auto" aria-label="Sort results">
+            <option value="relevance">Relevance</option>
+            <option value="nameAsc">Name A-Z</option>
+            <option value="nameDesc">Name Z-A</option>
+          </select>
+        </div>
+      </div>
 
       <!-- Collapsible section for switches -->
       <div class="collapse mt-3" id="filterOptions">
@@ -211,20 +226,6 @@
       </form>
     
     
-    <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-      <label for="page-size" class="form-label mb-0">Results per page</label>
-      <select id="page-size" class="form-select form-select-sm w-auto" aria-label="Results per page">
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50">50</option>
-      </select>
-      <label for="sort" class="form-label mb-0 ms-2">Sort</label>
-      <select id="sort" class="form-select form-select-sm w-auto" aria-label="Sort results">
-        <option value="relevance">Relevance</option>
-        <option value="nameAsc">Name A-Z</option>
-        <option value="nameDesc">Name Z-A</option>
-      </select>
-    </div>
     <div id="results" aria-live="polite"></div>
     <div id="loading-spinner" class="text-center my-3" style="display:none;">
       <div class="spinner-border" role="status">


### PR DESCRIPTION
## Summary
- arrange filter toggle with sort and results-per-page controls
- keep responsive layout using Bootstrap flex utility classes

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6879473be83c832dabcb01b1e9301d94