### PR TITLE
Fix filter count mapping for Non-SDN Menu-Based list

### DIFF
--- a/script.js
+++ b/script.js
@@ -192,7 +192,9 @@ function updateFilterCounts(sources) {
     sources.forEach((src) => {
       const match = src.value.match(/\(([^()]+)\)/);
       if (match && match[1]) {
-        counts[match[1]] = src.count;
+        let acronym = match[1];
+        if (acronym === 'NS-MBS List') acronym = 'MBS';
+        counts[acronym] = src.count;
       }
     });
   }


### PR DESCRIPTION
## Summary
- correct acronym parsing when calculating filter counts

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a67edfe30832daa90206719ff224f